### PR TITLE
WindowsSerialBugfixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakePythonSetting">
+    <option name="pythonIntegrationState" value="YES" />
+  </component>
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/usb-power-osd.iml" filepath="$PROJECT_DIR$/.idea/usb-power-osd.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/usb-power-osd.iml
+++ b/.idea/usb-power-osd.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ On Screen Display for my USB-C Power Meter (compatible to PLD's)
 sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev
 ```
 
+### Windows
+#### Prerequisites
+Jetbrains CLion is my IDE of choice, it already has with cmake and ninja bundled.
+
+Building on Windows is only tested using mingw, I recently used https://github.com/niXman/mingw-builds-binaries/releases.
+
+
+
 ## Running
 ### Linux
 You need to have access to `/dev/ttyUSB*`, this is usually managed by adding your use to a special group.

--- a/SerialThread.cpp
+++ b/SerialThread.cpp
@@ -54,8 +54,17 @@ bool SerialThread::measure_loop(const std::string &device) {
         std::cerr << "Failed to open" << device << " return code=" << code << std::endl;
         return false;
     }
+
+    // Debug: Verfügbare Bytes vor dem Lesen
+    std::cerr << "Bytes available before read: " << port->available() << std::endl;
+    
+    port->flushReceiver();  // Puffer leeren
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    
+    // Debug: Verfügbare Bytes nach Flush
+    std::cerr << "Bytes available after flush: " << port->available() << std::endl;
     char line[100];
-    int bytes_read = port->readString(line, '\n', 100, 1000);
+    int bytes_read = port->readString(line, '\n', 100, 5000);
     if (bytes_read < 0) {
         std::cerr << "Read error" << std::endl;
         return false;

--- a/SerialThread.cpp
+++ b/SerialThread.cpp
@@ -51,18 +51,15 @@ bool SerialThread::measure_loop(const std::string &device) {
     auto port = new serialib();
     char code;
     if ((code = port->openDevice(device.c_str(), 9600)) != 1) {
-        std::cerr << "Failed to open" << device << " return code=" << code << std::endl;
-        return false;
+      std::cerr << "Failed to open" << device << " return code=" << code
+                << std::endl;
+      return false;
     }
 
-    // Debug: Verfügbare Bytes vor dem Lesen
-    std::cerr << "Bytes available before read: " << port->available() << std::endl;
-    
+    // ReSharper disable once CppExpressionWithoutSideEffects
     port->flushReceiver();  // Puffer leeren
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     
-    // Debug: Verfügbare Bytes nach Flush
-    std::cerr << "Bytes available after flush: " << port->available() << std::endl;
     char line[100];
     int bytes_read = port->readString(line, '\n', 100, 5000);
     if (bytes_read < 0) {

--- a/serialib.cpp
+++ b/serialib.cpp
@@ -21,11 +21,13 @@ This is a licence-free software, it can be used by anyone who try to build a bet
 #include "serialib.h"
 
 #include <iostream>
-#include <bits/ostream.tcc>
 
 #include "SerialThread.h"
 #include "wx/utils.h"
 
+#if defined (_WIN32) || defined( _WIN64)
+#include <bits/ostream.tcc>
+#endif
 
 //_____________________________________
 // ::: Constructors and destructors :::

--- a/serialib.cpp
+++ b/serialib.cpp
@@ -221,6 +221,9 @@ char serialib::openDevice(const char *Device, const unsigned int Bauds,
     // configure parity
     dcbSerialParams.Parity = parity;
 
+    dcbSerialParams.fBinary = TRUE;
+    dcbSerialParams.fDtrControl = DTR_CONTROL_ENABLE;
+
     // Write the parameters
     if(!SetCommState(hSerial, &dcbSerialParams)) return -5;
 
@@ -237,7 +240,8 @@ char serialib::openDevice(const char *Device, const unsigned int Bauds,
     // Write the parameters
     if (!SetCommTimeouts(hSerial, timeouts)) return -6;
 
-    // Opening successfull
+    // Opening successful
+    std::cerr << "Open successful" <<std::endl;
     return 1;
 #endif
 #if defined (__linux__) || defined(__APPLE__)

--- a/serialib.cpp
+++ b/serialib.cpp
@@ -19,6 +19,10 @@ This is a licence-free software, it can be used by anyone who try to build a bet
 // ReSharper disable CppDFAConstantParameter
 // ReSharper disable CppDFAConstantConditions
 #include "serialib.h"
+
+#include <iostream>
+#include <bits/ostream.tcc>
+
 #include "SerialThread.h"
 #include "wx/utils.h"
 
@@ -609,63 +613,43 @@ int serialib::readStringNoTimeOut(char *receivedString, char finalChar, unsigned
   */
 int serialib::readString(char *receivedString, char finalChar, unsigned int maxNbBytes, unsigned int timeOut_ms,
                          bool stripFinalChar) const {
-    // Check if timeout is requested
     if (timeOut_ms == 0) return readStringNoTimeOut(receivedString, finalChar, maxNbBytes);
 
-    // Number of bytes read
     unsigned int nbBytes = 0;
-    // Character read on serial device
     char charRead;
-    // Timer used for timeout
     timeOut timer;
     long int timeOutParam;
 
-    // Initialize the timer (for timeout)
     timer.initTimer();
 
-    // While the buffer is not full
     while (nbBytes < maxNbBytes) {
-        if (this->available() == 0) {
-            wxMilliSleep(50);
-        }
-        // Compute the TimeOut for the next call of ReadChar
+        // Compute timeout first
         timeOutParam = timeOut_ms - timer.elapsedTime_ms();
-
-        // If there is time remaining
-        if (timeOutParam > 0) {
-            // Wait for a byte on the serial link with the remaining time as timeout
-            charRead = readChar(&receivedString[nbBytes], timeOutParam);
-
-            // If a byte has been received
-            if (charRead == 1) {
-                // Check if the character received is the final one
-                if (receivedString[nbBytes] == finalChar) {
-                    if (stripFinalChar) {
-                        nbBytes--;
-                    }
-                    // Final character: add the end character 0
-                    receivedString[++nbBytes] = 0;
-                    // Return the number of bytes read
-                    return nbBytes;
-                }
-                // This is not the final character, just increase the number of bytes read
-                nbBytes++;
-            }
-            // Check if an error occured during reading char
-            // If an error occurend, return the error number
-            if (charRead < 0) return charRead;
-        }
-        // Check if timeout is reached
-        if (timer.elapsedTime_ms() > timeOut_ms) {
-            // Add the end caracter
+        
+        if (timeOutParam <= 0) {
+            // Timeout reached
             receivedString[nbBytes] = 0;
-            // Return 0 (timeout reached)
             return 0;
+        }
+
+        // Wait for a byte with proper timeout
+        charRead = readChar(&receivedString[nbBytes], timeOutParam);
+
+        if (charRead == 1) {
+            if (receivedString[nbBytes] == finalChar) {
+                if (stripFinalChar) {
+                    nbBytes--;
+                }
+                receivedString[++nbBytes] = 0;
+                return nbBytes;
+            }
+            nbBytes++;
+        } else if (charRead < 0) {
+            return charRead;
         }
     }
 
-    // Buffer is full : return -3
-    return -3;
+    return -3;  // Buffer full
 }
 
 

--- a/serialib.cpp
+++ b/serialib.cpp
@@ -617,7 +617,7 @@ int serialib::readString(char *receivedString, char finalChar, unsigned int maxN
                          bool stripFinalChar) const {
     if (timeOut_ms == 0) return readStringNoTimeOut(receivedString, finalChar, maxNbBytes);
 
-    unsigned int nbBytes = 0;
+    int nbBytes = 0;
     char charRead;
     timeOut timer;
     long int timeOutParam;
@@ -628,6 +628,14 @@ int serialib::readString(char *receivedString, char finalChar, unsigned int maxN
         // Compute timeout first
         timeOutParam = timeOut_ms - timer.elapsedTime_ms();
         
+        if (timeOutParam <= 0) {
+            // Timeout reached
+            receivedString[nbBytes] = 0;
+            return 0;
+        }
+        while (!available() && timeOut_ms - timer.elapsedTime_ms() > 0) {
+            wxMilliSleep(25);
+        }
         if (timeOutParam <= 0) {
             // Timeout reached
             receivedString[nbBytes] = 0;


### PR DESCRIPTION
The Windows implementation of the serial "driver" was bad in that it always reset the connected mcu, which resulted in a communcation error because the mcu's splash screen prevented communication for longer than the initial timeout was specified.
There also was a bug in serial thread sleep algorithm that may have made the application misbehave. Crosschecking on macOS/Linux is needed if this unneededly raises cpu usage.